### PR TITLE
fix: use default export for prerendering

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -80,4 +80,4 @@ if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
     run();
 }
 
-export * from './src/main.server';
+export default bootstrap;


### PR DESCRIPTION
Re-exporting from `main.server.ts` does not provide the default export